### PR TITLE
Added a guard for the Fast Forward

### DIFF
--- a/Scripts/TimedAnimation.cs
+++ b/Scripts/TimedAnimation.cs
@@ -129,7 +129,10 @@ namespace DUCK.Tween
 			// Set the animation state to its final form
 			CurrentTime = Duration;
 			Refresh(Progress);
-			AnimationDriver.Remove(Update);
+			if (IsPlaying)
+			{
+				AnimationDriver.Remove(Update);
+			}
 			base.FastForward();
 		}
 


### PR DESCRIPTION
It fixes a rare case when you fast forward a collection on the frame of the current animation being finished it will crash...

In addition, this enables the ability that you can fast forward an animation without playing it. Could be very useful for skipping animations, etc.