### PR TITLE
Merge Master into Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@
 A simple to use tween library, for moving things with code
 
 ## What are the requirements?
- * Unity 2018.x
+ * Unity 2018.x +
+
+# Contributing
+
+## Releasing
+* Use [gitflow](https://nvie.com/posts/a-successful-git-branching-model/)
+* Create a release branch for the release
+* On that branch, bump version number in package json file, any other business (docs/readme updates)
+* Merge to master via pull request and tag the merge commit on master.
+* Merge back to development.
+
+## DUCK
+
+This repo is part of DUCK (dubit unity component kit)
+DUCK is a series of repos containing reusable component, utils, systems & tools. 
+
+DUCK packages can be added to a project as git submodules or by using [Unity Package Manager](https://docs.unity3d.com/Manual/upm-git.html). 
 
 ## How to use it
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "com.dubitlimited.duck.tween",
+  "displayName": "Duck Tween",
+  "version": "1.4.0",
+  "description": "A tween library for unity",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dubit/duck-tween"
+  },
+  "author": "Dubit Limited"
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9cd576caa75cc0643915f0feed655f55
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
For some reason development is the main branch in the repository settings. This is causing release branches to merge to master but never to development. This pull request doesn't fix the problem, but at least updates development for now.

For anyone to use the latest Master release in Unity's Package manager, you must include the revision for the latest master commit:
`"com.dubitlimited.duck.tween": "https://github.com/dubit/duck-tween.git#89dec6876a590456ae2efa7c235b84834c56472c"`

and manually update this in each project for each release.

To fix this: Master should be set as the base branch.
 